### PR TITLE
Board Paper API 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+*.env

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
+    "@tanstack/react-query": "^5.64.1",
+    "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@emotion/styled':
         specifier: ^11.13.5
         version: 11.13.5(@emotion/react@11.13.5(@types/react@18.3.14)(react@18.3.1))(@types/react@18.3.14)(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.64.1
+        version: 5.64.1(react@18.3.1)
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -829,6 +835,14 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
+  '@tanstack/query-core@5.64.1':
+    resolution: {integrity: sha512-978Wx4Wl4UJZbmvU/rkaM9cQtXXrbhK0lsz/UZhYIbyKYA8E4LdomTwyh2GHZ4oU0BKKoDH4YlKk2VscCUgNmg==}
+
+  '@tanstack/react-query@5.64.1':
+    resolution: {integrity: sha512-vW5ggHpIO2Yjj44b4sB+Fd3cdnlMJppXRBJkEHvld6FXh3j5dwWJoQo7mGtKI2RbSFyiyu/PhGAy0+Vv5ev9Eg==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -1051,9 +1065,15 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -1142,6 +1162,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1225,6 +1249,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1456,8 +1484,21 @@ packages:
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+
+  form-data@4.0.1:
+    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+    engines: {node: '>= 6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1801,6 +1842,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1937,6 +1986,9 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3119,6 +3171,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/query-core@5.64.1': {}
+
+  '@tanstack/react-query@5.64.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.64.1
+      react: 18.3.1
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -3405,9 +3464,19 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
+
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -3494,6 +3563,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
@@ -3572,6 +3645,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -3907,9 +3982,17 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  follow-redirects@1.15.9: {}
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.1:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   fsevents@2.3.3:
     optional: true
@@ -4237,6 +4320,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -4372,6 +4461,8 @@ snapshots:
       react-is: 17.0.2
 
   process@0.11.10: {}
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -1,5 +1,5 @@
-import { http } from "@/utils/http";
 import { GetBoardRequestParam, GetBoardResponse, PostBoardRequest, PostBoardResponse } from "@/types/services";
+import { http } from "@/utils/http";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -1,7 +1,8 @@
+import { getEnvVariable } from "@/env";
 import { GetBoardRequestParam, GetBoardResponse, PostBoardRequest, PostBoardResponse } from "@/types/services";
 import { http } from "@/utils/http";
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = getEnvVariable("VITE_API_BASE_URL");
 
 export const postBoard = async (data: PostBoardRequest) => {
   return http.post<PostBoardRequest, PostBoardResponse>(`${API_BASE_URL}/board`, data);

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -1,0 +1,12 @@
+import { http } from "@/utils/http";
+import { GetBoardRequestParam, GetBoardResponse, PostBoardRequest, PostBoardResponse } from "@/types/services";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export const postBoard = async (data: PostBoardRequest) => {
+  return http.post<PostBoardRequest, PostBoardResponse>(`${API_BASE_URL}/board`, data);
+};
+
+export const getBoard = async (data: GetBoardRequestParam) => {
+  return http.get<GetBoardResponse>(`${API_BASE_URL}/board/${data.id}`);
+};

--- a/src/apis/paper.ts
+++ b/src/apis/paper.ts
@@ -1,7 +1,8 @@
+import { getEnvVariable } from "@/env";
 import { PostPaperRequest, PostPaperResponse, GetPaperRequestParam, GetPaperResponse } from "@/types/services";
 import { http } from "@/utils/http";
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = getEnvVariable("VITE_API_BASE_URL");
 
 export const postPaper = async (data: PostPaperRequest) => {
   return http.post<PostPaperRequest, PostPaperResponse>(`${API_BASE_URL}/paper`, data);

--- a/src/apis/paper.ts
+++ b/src/apis/paper.ts
@@ -1,5 +1,5 @@
-import { http } from "@/utils/http";
 import { PostPaperRequest, PostPaperResponse, GetPaperRequestParam, GetPaperResponse } from "@/types/services";
+import { http } from "@/utils/http";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/apis/paper.ts
+++ b/src/apis/paper.ts
@@ -1,0 +1,12 @@
+import { http } from "@/utils/http";
+import { PostPaperRequest, PostPaperResponse, GetPaperRequestParam, GetPaperResponse } from "@/types/services";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export const postPaper = async (data: PostPaperRequest) => {
+  return http.post<PostPaperRequest, PostPaperResponse>(`${API_BASE_URL}/paper`, data);
+};
+
+export const getPaper = async (data: GetPaperRequestParam) => {
+  return http.get<GetPaperResponse>(`${API_BASE_URL}/paper/${data.id}`);
+};

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,0 +1,6 @@
+const QUERY_KEY = {
+  board: "board",
+  paper: "paper",
+};
+
+export default QUERY_KEY;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,7 @@
+export const getEnvVariable = (key: string): string => {
+  const value = import.meta.env[key];
+  if (!value) {
+    throw new Error(`${key} 환경 변수가 설정되지 않았습니다.`);
+  }
+  return value;
+};

--- a/src/hooks/useRequestGetBoard.ts
+++ b/src/hooks/useRequestGetBoard.ts
@@ -1,6 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
+
 import { getBoard } from "@/apis/board";
 import QUERY_KEY from "@/constants/queryKey";
-import { useQuery } from "@tanstack/react-query";
 
 export const useRequestGetBoard = (id: number) => {
   const { data, ...rest } = useQuery({

--- a/src/hooks/useRequestGetBoard.ts
+++ b/src/hooks/useRequestGetBoard.ts
@@ -1,0 +1,12 @@
+import { getBoard } from "@/apis/board";
+import QUERY_KEY from "@/constants/queryKey";
+import { useQuery } from "@tanstack/react-query";
+
+export const useRequestGetBoard = (id: number) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [QUERY_KEY.board, id],
+    queryFn: () => getBoard({ id }),
+  });
+
+  return { data, ...rest };
+};

--- a/src/hooks/useRequestGetPaper.ts
+++ b/src/hooks/useRequestGetPaper.ts
@@ -1,0 +1,13 @@
+import { getPaper } from "@/apis/paper";
+import QUERY_KEY from "@/constants/queryKey";
+import { useQuery } from "@tanstack/react-query";
+
+export const useRequestGetPaper = (id: number) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [QUERY_KEY.paper, id],
+    queryFn: () => getPaper({ id }),
+  });
+
+  return { data, ...rest };
+};
+

--- a/src/hooks/useRequestGetPaper.ts
+++ b/src/hooks/useRequestGetPaper.ts
@@ -1,6 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
+
 import { getPaper } from "@/apis/paper";
 import QUERY_KEY from "@/constants/queryKey";
-import { useQuery } from "@tanstack/react-query";
 
 export const useRequestGetPaper = (id: number) => {
   const { data, ...rest } = useQuery({

--- a/src/hooks/useRequestPostBoard.ts
+++ b/src/hooks/useRequestPostBoard.ts
@@ -1,0 +1,17 @@
+import { postBoard } from "@/apis/board";
+import QUERY_KEY from "@/constants/queryKey";
+import { PostBoardRequest } from "@/types/services";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useRequestPostBoard = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: (data: PostBoardRequest) => postBoard(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.board] });
+    },
+  });
+
+  return { mutate, ...rest };
+};

--- a/src/hooks/useRequestPostBoard.ts
+++ b/src/hooks/useRequestPostBoard.ts
@@ -1,7 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { postBoard } from "@/apis/board";
 import QUERY_KEY from "@/constants/queryKey";
 import { PostBoardRequest } from "@/types/services";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const useRequestPostBoard = () => {
   const queryClient = useQueryClient();

--- a/src/hooks/useRequestPostPaper.ts
+++ b/src/hooks/useRequestPostPaper.ts
@@ -1,7 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { postPaper } from "@/apis/paper";
 import QUERY_KEY from "@/constants/queryKey";
 import { PostPaperRequest } from "@/types/services";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const useRequestPostPaper = () => {
   const queryClient = useQueryClient();

--- a/src/hooks/useRequestPostPaper.ts
+++ b/src/hooks/useRequestPostPaper.ts
@@ -1,0 +1,17 @@
+import { postPaper } from "@/apis/paper";
+import QUERY_KEY from "@/constants/queryKey";
+import { PostPaperRequest } from "@/types/services";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export const useRequestPostPaper = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn: (data: PostPaperRequest) => postPaper(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.paper] });
+    },
+  });
+
+  return { mutate, ...rest };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 
 import router from './router'
 import { DesignProvider } from './theme/DesignProvider'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,16 @@ import { RouterProvider } from 'react-router-dom'
 
 import router from './router'
 import { DesignProvider } from './theme/DesignProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <DesignProvider>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </DesignProvider>
   </StrictMode>,
 )

--- a/src/pages/create/NameStep.tsx
+++ b/src/pages/create/NameStep.tsx
@@ -1,8 +1,10 @@
-import { VStack } from "@/components/Stack";
-import Top from "@/components/Top/Top";
+import { BoardFormData, Step } from "./page";
+
 import FixedBottomCTA from "@/components/FixedBottomCTA/FixedBottomCTA";
 import { Input } from "@/components/Input";
-import { BoardFormData, Step } from "./page";
+import { VStack } from "@/components/Stack";
+import Top from "@/components/Top/Top";
+
 
 interface NameStepProps {
   formData: BoardFormData;

--- a/src/pages/create/PasswordStep.tsx
+++ b/src/pages/create/PasswordStep.tsx
@@ -1,8 +1,10 @@
-import { VStack } from "@/components/Stack";
-import Top from "@/components/Top/Top";
+import { BoardFormData, Step } from "./page";
+
 import FixedBottomCTA from "@/components/FixedBottomCTA/FixedBottomCTA";
 import { Input } from "@/components/Input";
-import { BoardFormData, Step } from "./page";
+import { VStack } from "@/components/Stack";
+import Top from "@/components/Top/Top";
+
 
 interface PasswordStepProps {
   formData: BoardFormData;

--- a/src/pages/create/ShowDateStep.tsx
+++ b/src/pages/create/ShowDateStep.tsx
@@ -1,8 +1,10 @@
-import { VStack } from "@/components/Stack";
-import Top from "@/components/Top/Top";
+import { BoardFormData } from "./page";
+
 import FixedBottomCTA from "@/components/FixedBottomCTA/FixedBottomCTA";
 import { Input } from "@/components/Input";
-import { BoardFormData } from "./page";
+import { VStack } from "@/components/Stack";
+import Top from "@/components/Top/Top";
+
 
 interface ShowDateStepProps {
   formData: BoardFormData;

--- a/src/pages/create/page.tsx
+++ b/src/pages/create/page.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useState } from 'react';
+
 import NameStep from './NameStep';
 import PasswordStep from './PasswordStep';
 import ShowDateStep from './ShowDateStep';

--- a/src/pages/create/page.tsx
+++ b/src/pages/create/page.tsx
@@ -19,11 +19,15 @@ export default function CreatePage() {
     showDate: '',
   });
 
+  const handleSubmit = () => {
+    console.log(formData);
+  }
+
   return (
     <>
       {step === 'name' ? <NameStep formData={formData} setFormData={setFormData} setStep={setStep} /> : null}
       {step === 'password' ? <PasswordStep formData={formData} setFormData={setFormData} setStep={setStep} /> : null}
-      {step === 'showDate' ? <ShowDateStep formData={formData} setFormData={setFormData} onSubmit={()=>{}} /> : null}
+      {step === 'showDate' ? <ShowDateStep formData={formData} setFormData={setFormData} onSubmit={handleSubmit} /> : null}
     </>
   );
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,0 +1,12 @@
+export type Board = {
+  id: number;
+  name: string;
+  showDate: string;
+};
+
+export type Paper = {
+  id: number;
+  boardId: number;
+  name: string;
+  content: string;
+};

--- a/src/types/services.ts
+++ b/src/types/services.ts
@@ -1,0 +1,46 @@
+export type PostBoardRequest = {
+  name: string;
+  password: string;
+  showDate: string;
+};
+
+export type PostBoardResponse = {
+  id: number;
+  name: string;
+  showDate: string;
+};
+
+export type GetBoardRequestParam = {
+  id: number;
+}
+
+export type GetBoardResponse = {
+  id: number;
+  name: string;
+  showDate: string;
+};
+
+export type PostPaperRequest = {
+  boardId: number;
+  name: string;
+  content: string;
+};
+
+export type PostPaperResponse = {
+  id: number;
+  boardId: number;
+  name: string;
+  content: string;
+};
+
+export type GetPaperRequestParam = {
+  id: number;
+};
+
+export type GetPaperResponse = {
+  id: number;
+  boardId: number;
+  createdAt: string;
+  name: string;
+  content: string;
+};

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,16 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+export const http = {
+  get: async function get<Response = unknown>(url: string, options: AxiosRequestConfig = {}) {
+    const res = await axios.get<Response>(url, options);
+    return res.data;
+  },
+  post: async function post<Request = any, Response = unknown>(url: string, data?: Request) {
+    const res = await axios.post<Response>(url, { ...data });
+    return res.data;
+  },
+  put: async function put<Request = any, Response = unknown>(url: string, data?: Request) {
+    const res = await axios.put<Response>(url, { ...data });
+    return res.data;
+  },
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 게시판 및 페이퍼 생성, 조회를 위한 API 지원
	- React Query를 사용한 데이터 관리 기능 추가
	- `CreatePage`에서 제출 핸들러 기능 추가

- **의존성 추가**
	- `@tanstack/react-query` 라이브러리 도입
	- `axios` HTTP 클라이언트 라이브러리 추가

- **개선 사항**
	- 환경 변수 파일(`.env`) Git 추적 제외
	- 데이터 요청 및 상태 관리를 위한 훅(hooks) 개발
	- HTTP 요청을 위한 유틸리티 모듈 추가

- **타입 정의**
	- 게시판과 페이퍼를 위한 새로운 타입 모델 추가
	- API 요청 및 응답을 위한 타입스크립트 타입 정의
<!-- end of auto-generated comment: release notes by coderabbit.ai -->