### PR TITLE
DatePicker 일시적으로 input으로 변경

### DIFF
--- a/src/components/BoardPageView/BoardPageView.tsx
+++ b/src/components/BoardPageView/BoardPageView.tsx
@@ -72,7 +72,7 @@ export default function BoardPageView({isAdmin = false}: Props) {
           <PaperThumbnailGrid papers={responses ?? []} />
         </VStack>
       )}
-      {!isAdmin && daysForShow <= 0 && (
+      {!isAdmin && (
         <FixedBottomCTA>
           <Button display="full" size="lg" onClick={() => navigate(`/${boardId}/create-paper`)}>
             메세지 남기기

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -2,7 +2,6 @@ import {Input} from '@components/Input';
 
 import type {Meta, StoryObj} from '@storybook/react';
 
-
 const meta = {
   title: 'Components/Input',
   component: Input,
@@ -30,7 +29,7 @@ const meta = {
     autoFocus: {
       description: '자동 포커스 여부를 설정합니다',
       control: {type: 'boolean'},
-    }
+    },
   },
   args: {
     labelText: '라벨',

--- a/src/pages/create-board/ShowDateStep.tsx
+++ b/src/pages/create-board/ShowDateStep.tsx
@@ -1,13 +1,11 @@
 /** @jsxImportSource @emotion/react */
 
 import {Button} from '@components/Button';
-import {DateScrollPicker} from '@components/DateScrollPicker/DateScrollPicker';
 import FixedBottomCTA from '@components/FixedBottomCTA/FixedBottomCTA';
 import {Input} from '@components/Input';
 import {VStack} from '@components/Stack';
 import Top from '@components/Top/Top';
-import {YMD} from '@type/model';
-import {dateToYMD, YMDtoDateString} from '@utils/date';
+import {dateToYMD, YMDtoYYYYMMDD} from '@utils/date';
 
 import {BoardFormData, Step} from './page';
 
@@ -19,10 +17,9 @@ interface ShowDateStepProps {
 }
 
 export default function ShowDateStep({formData, setFormData, onSubmit, setStep}: ShowDateStepProps) {
-  const now = dateToYMD(new Date());
-
-  const handleDateChange = (date: YMD) => {
-    setFormData({...formData, showDate: date});
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const date = e.target.value;
+    setFormData({...formData, showDate: dateToYMD(new Date(date))});
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -37,8 +34,8 @@ export default function ShowDateStep({formData, setFormData, onSubmit, setStep}:
         <Top.Line text="날짜를 정해주세요" emphasize={['날짜']} />
       </Top>
       <form onSubmit={handleSubmit} css={{width: '100%', display: 'flex', flexDirection: 'column', gap: '2rem'}}>
-        <Input labelText="날짜" value={YMDtoDateString(formData.showDate)} disabled />
-        <DateScrollPicker onChange={handleDateChange} initialDate={now} />
+        <Input type="date" labelText="날짜" value={YMDtoYYYYMMDD(formData.showDate)} onChange={handleDateChange} />
+        {/* <DateScrollPicker onChange={handleDateChange} initialDate={now} /> */}
         <FixedBottomCTA direction="row">
           <Button variants="secondary" display="full" size="lg" onClick={() => setStep('password')}>
             이전

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -10,8 +10,16 @@ export const dateToYMD = (date: Date) => {
   return {year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()};
 };
 
+export const dateToYYYYMMDD = (date: Date) => {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+};
+
 export const YMDtoDateString = (ymd: YMD) => {
   return `${ymd.year}년 ${String(ymd.month).padStart(2, '0')}월 ${String(ymd.day).padStart(2, '0')}일`;
+};
+
+export const YMDtoYYYYMMDD = (ymd: YMD) => {
+  return `${ymd.year}-${String(ymd.month).padStart(2, '0')}-${String(ymd.day).padStart(2, '0')}`;
 };
 
 export const timeFromNow = (target: Date) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 보드 페이지의 하단 호출 버튼 표시 조건이 간소화되어, 관리자가 아닌 사용자에게 항상 노출됩니다.
	- 게시판 생성 단계에서 사용자 지정 날짜 선택기 대신 기본 HTML 날짜 입력을 사용하여 직관적인 날짜 선택 인터페이스를 제공합니다.
- **New Features**
	- 개선된 날짜 포맷 기능으로 날짜 입력 및 표시의 일관성이 확보되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->